### PR TITLE
feat(docker): Drops the need for build args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ jobs:
     - pip install --user awscli
     - export PATH=$PATH:$HOME/.local/bin
     - eval $(aws ecr get-login --no-include-email --region eu-west-1)
-    - echo "Building for playground"
-    - docker build --build-arg WT_CONFIG=playground -t wt-notification-api:$TRAVIS_BRANCH-playground .
-    - docker tag wt-notification-api:$TRAVIS_BRANCH-playground 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-notification-api:$TRAVIS_BRANCH-playground
-    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-notification-api:$TRAVIS_BRANCH-playground
+    - echo "Building docker image"
+    - docker build -t wt-notification-api:$TRAVIS_BRANCH .
+    - docker tag wt-notification-api:$TRAVIS_BRANCH 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-notification-api:$TRAVIS_BRANCH
+    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-notification-api:$TRAVIS_BRANCH
   - stage: Start service from docker with latest merged tag
     install: true
     sudo: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ RUN npm ci
 
 COPY . .
 
-ARG WT_CONFIG
-
-RUN npm run createdb
-
-CMD ["npm", "start"]
+CMD ["npm", "run", "docker-start"]
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ To run this "seriously", you will need to go through several steps:
 You can run the whole API in a docker container as well, and you can
 control which config will be used by passing an appropriate value
 to WT_CONFIG variable at runtime. Database will be setup during the
-container startup in the current setup.
+container startup in the current setup. You can skip this with
+`SKIP_DB_SETUP` environment variable.
 
 ```sh
 $ docker build -t windingtree/wt-notification-api .

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ To run this "seriously", you will need to go through several steps:
 ### Running in docker
 You can run the whole API in a docker container as well, and you can
 control which config will be used by passing an appropriate value
-to WT_CONFIG variable both during build time and runtime.
+to WT_CONFIG variable at runtime. Database will be setup during the
+container startup in the current setup.
 
 ```sh
-$ docker build --build-arg WT_CONFIG=playground -t windingtree/wt-notification-api .
+$ docker build -t windingtree/wt-notification-api .
 $ docker run -p 8080:8080 -e WT_CONFIG=playground windingtree/wt-notification-api
 ```
 - After that you can access the wt-write-api on local port `8080`

--- a/management/createdb.js
+++ b/management/createdb.js
@@ -1,7 +1,7 @@
 const { setupDB } = require('../src/db');
 
 setupDB().then(() => {
-  console.log('Created');
+  console.log('DB is all set');
   process.exit(0);
 }, (err) => {
   console.log(`Error: ${err}`);

--- a/management/createdb.js
+++ b/management/createdb.js
@@ -1,3 +1,8 @@
+if (process.env.SKIP_DB_SETUP) {
+  console.log('Skipping DB setup');
+  process.exit(0);
+}
+
 const { setupDB } = require('../src/db');
 
 setupDB().then(() => {

--- a/management/deploy-aws.sh
+++ b/management/deploy-aws.sh
@@ -32,7 +32,7 @@ TASK_DEF="[{\"portMappings\": [{\"hostPort\": 0,\"protocol\": \"tcp\",\"containe
         \"value\": \"$WT_CONFIG\"
       }
     ],
-    \"image\": \"029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-notification-api:$LATEST_TAG-$ENVIRONMENT\",
+    \"image\": \"029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-notification-api:$LATEST_TAG\",
     \"name\": \"wt-notification-api\",
     \"memoryReservation\": 128,
     \"cpu\": 128

--- a/management/deploy-aws.sh
+++ b/management/deploy-aws.sh
@@ -24,7 +24,7 @@ TASK_DEF="[{\"portMappings\": [{\"hostPort\": 0,\"protocol\": \"tcp\",\"containe
     },
     \"environment\": [
       {
-        \"name\": \"WT_API_BASE_URL\",
+        \"name\": \"BASE_URL\",
         \"value\": \"https://$ENVIRONMENT-notification-api.windingtree.com\"
       },
       {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "WT_CONFIG=test ./node_modules/.bin/nyc --reporter=text ./node_modules/mocha/bin/mocha --recursive --timeout 20000",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "start": "node src/index.js",
+    "docker-start": "npm run createdb && npm start",
     "dev": "WT_CONFIG=dev node src/index.js",
     "dev-consumer": "node management/dev-consumer.js",
     "createdb-dev": "WT_CONFIG=dev node management/createdb.js",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,7 +4,7 @@ const env = process.env.WT_CONFIG || 'dev';
 
 module.exports = Object.assign({
   port: 8080,
-  baseUrl: process.env.WT_API_BASE_URL || 'http://localhost:8080',
+  baseUrl: process.env.BASE_URL || 'http://localhost:8080',
   logger: winston.createLogger({
     level: 'info',
     transports: [


### PR DESCRIPTION
This PR simplifies our AWS deployment by dropping the need to build the container twice (once for demo, once for playground). However, the containers are still pinned to sqlite, so it's not really that re-usable for a wider audience.